### PR TITLE
Patch highWaterMark fix from 0.11.7

### DIFF
--- a/lib/_base.js
+++ b/lib/_base.js
@@ -15,7 +15,12 @@ module.exports = ObjectStream
  * @constructor
  */
 function ObjectStream() {
-  Transform.call(this, {objectMode: true})
+  Transform.call(this, {
+    objectMode: true,
+    // Patch from 0.11.7
+    // https://github.com/joyent/node/commit/ba72570eae938957d10494be28eac28ed75d256f
+    highWaterMark: 16
+  })
 }
 util.inherits(ObjectStream, Transform)
 


### PR DESCRIPTION
Hello @evansolomon, 

Please review the following commits I made in branch 'es-highwatermark'.

91636e5d8d8600713d67d91e2ec01dfb5f2d84cb (2014-03-27 15:55:26 -0400)
Patch highWaterMark fix from 0.11.7
Makes backpressure behave sanely.

R=@evansolomon
