### PR TITLE
Browser support

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,16 @@
 /**
  * @fileoverview Export all of the public modules.
  */
-var fs = require('fs')
-var path = require('path')
-
-var libPath = path.join(__dirname, 'lib')
-fs.readdirSync(libPath).forEach(function (lib) {
-  var name = lib.replace('.js', '')
-  exports[name] = require(path.join(libPath, name))
-})
+module.exports = {
+  append     : require('./lib/append'),
+  byteLength : require('./lib/byteLength'),
+  filter     : require('./lib/filter'),
+  fork       : require('./lib/fork'),
+  invoke     : require('./lib/invoke'),
+  join       : require('./lib/join'),
+  map        : require('./lib/map'),
+  prepend    : require('./lib/prepend'),
+  replace    : require('./lib/replace'),
+  split      : require('./lib/split'),
+  tap        : require('./lib/tap')
+};


### PR DESCRIPTION
Webpack was choking on requiring the index.js file, because
it was trying to use the fs module to iterate over files.

There's also no real reason to get fancy here, because hardly
any typing is saved, and even if you saved some chars here,
it's not like this is boilerplate the user has to type over
and over.

Webpack and browserify work through an AST provided by esprima,
so you have to explicitly specify the strings of the modules,
(with a few exceptions).
